### PR TITLE
re-raise openssl exceptions as Faraday::SSLError for consistency

### DIFF
--- a/lib/faraday/adapter/http.rb
+++ b/lib/faraday/adapter/http.rb
@@ -26,6 +26,12 @@ module Faraday
         raise Faraday::TimeoutError, $ERROR_INFO
       rescue ::HTTP::ConnectionError
         raise Faraday::ConnectionFailed, $ERROR_INFO
+      rescue StandardError => e
+        if defined?(OpenSSL) && e.is_a?(OpenSSL::SSL::SSLError)
+          raise Faraday::SSLError, e
+        end
+
+        raise
       end
 
       def setup_connection(env)


### PR DESCRIPTION
Ensures the `http` adapter raises `Faraday::SSLError` like the other adapters. This failure is from the [faraday-live project](https://github.com/technoweenie/faraday-live):

```
  13) http with unverified HTTPS server fails with verification enabled
      Failure/Error:
        expect do
          conn.get('unverified_with_verification')
        end.to raise_error(Faraday::SSLError)

        expected Faraday::SSLError, got #<OpenSSL::SSL::SSLError: SSL_connect returned=1 errno=0 state=error: certificate verify failed (unable to get local issuer certificate)> with backtrace:
          # /usr/local/bundle/gems/http-3.3.0/lib/http/timeout/null.rb:27:in `connect'
          # /usr/local/bundle/gems/http-3.3.0/lib/http/timeout/null.rb:27:in `connect_ssl'
          # /usr/local/bundle/gems/http-3.3.0/lib/http/timeout/null.rb:36:in `start_tls'
          # /usr/local/bundle/gems/http-3.3.0/lib/http/connection.rb:162:in `start_tls'
          # /usr/local/bundle/gems/http-3.3.0/lib/http/connection.rb:46:in `initialize'
          # /usr/local/bundle/gems/http-3.3.0/lib/http/client.rb:67:in `new'
          # /usr/local/bundle/gems/http-3.3.0/lib/http/client.rb:67:in `perform'
          # /usr/local/bundle/gems/http-3.3.0/lib/http/client.rb:30:in `request'
          # /usr/local/bundle/bundler/gems/faraday-http-df11f33cc122/lib/faraday/adapter/http.rb:23:in `perform_request'
          # /usr/local/bundle/bundler/gems/faraday-http-df11f33cc122/lib/faraday/adapter/http.rb:14:in `call'
          # /usr/local/bundle/bundler/gems/faraday-be097190e962/lib/faraday/request/url_encoded.rb:23:in `call'
          # /usr/local/bundle/bundler/gems/faraday-be097190e962/lib/faraday/rack_builder.rb:153:in `build_response'
          # /usr/local/bundle/bundler/gems/faraday-be097190e962/lib/faraday/connection.rb:504:in `run_request'
          # /usr/local/bundle/bundler/gems/faraday-be097190e962/lib/faraday/connection.rb:207:in `get'
          # ./spec/insecure_spec.rb:33:in `block (4 levels) in <top (required)>'
          # ./spec/insecure_spec.rb:32:in `block (3 levels) in <top (required)>'
      # ./spec/insecure_spec.rb:32:in `block (3 levels) in <top (required)>'
```