### PR TITLE
create custom SSL context from Faraday::SSLOptions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,13 +15,23 @@ Style/HashTransformKeys:
 Style/HashTransformValues:
   Enabled: true
 
+Metrics/MethodLength:
+  Max: 30
+
 Metrics/LineLength:
   Max: 100
 
 Metrics/AbcSize:
-  Max: 20
+  Max: 25
 
 Metrics/BlockLength:
   Exclude:
     - spec/**/*.rb
     - faraday-http.gemspec
+
+Metrics/CyclomaticComplexity:
+  Max: 30
+
+Metrics/PerceivedComplexity:
+  Max: 10
+

--- a/lib/faraday/adapter/http.rb
+++ b/lib/faraday/adapter/http.rb
@@ -23,8 +23,8 @@ module Faraday
         conn = setup_connection(env)
 
         resp = conn.request env[:method], env[:url],
-          body: env[:body],
-          ssl_context: ssl_context(env[:ssl])
+                            body: env[:body],
+                            ssl_context: ssl_context(env[:ssl])
 
         save_response(env, resp.code, resp.body.to_s, resp.headers, resp.status.reason)
       rescue ::HTTP::TimeoutError
@@ -62,8 +62,8 @@ module Faraday
 
       def ssl_context(ssl)
         params = {}
-        [
-          :ca_file, :ca_path, :cert_store, :verify_depth,
+        %i[
+          ca_file ca_path cert_store verify_depth
         ].each do |key|
           if (value = ssl[key])
             params[key] = value
@@ -98,11 +98,11 @@ module Faraday
 
       def ssl_client_cert(cert)
         case cert
-        when NilClass then return
+        when NilClass then nil
         when String
-          return OpenSSL::X509::Certificate.new(File.read(cert))
+          OpenSSL::X509::Certificate.new(File.read(cert))
         when OpenSSL::X509::Certificate
-          return cert
+          cert
         else
           raise Faraday::Error, "invalid ssl.client_cert: #{cert.inspect}"
         end
@@ -110,11 +110,11 @@ module Faraday
 
       def ssl_client_key(cert)
         case cert
-        when NilClass then return
+        when NilClass then nil
         when String
-          return OpenSSL::PKey::RSA.new(File.read(cert))
+          OpenSSL::PKey::RSA.new(File.read(cert))
         when OpenSSL::PKey::RSA, OpenSSL::PKey::DSA
-          return cert
+          cert
         else
           raise Faraday::Error, "invalid ssl.client_key: #{cert.inspect}"
         end

--- a/lib/faraday/adapter/http.rb
+++ b/lib/faraday/adapter/http.rb
@@ -4,6 +4,8 @@ module Faraday
   class Adapter
     # HTTP.rb adapter.
     class HTTP < Faraday::Adapter
+      dependency 'http'
+
       # Takes the environment and performs the request.
       #
       # @param env [Faraday::Env] the request environment.
@@ -20,7 +22,10 @@ module Faraday
       def perform_request(env)
         conn = setup_connection(env)
 
-        resp = conn.request env[:method], env[:url], body: env[:body]
+        resp = conn.request env[:method], env[:url],
+          body: env[:body],
+          ssl_context: ssl_context(env[:ssl])
+
         save_response(env, resp.code, resp.body.to_s, resp.headers, resp.status.reason)
       rescue ::HTTP::TimeoutError
         raise Faraday::TimeoutError, $ERROR_INFO
@@ -53,6 +58,66 @@ module Faraday
         end
 
         conn
+      end
+
+      def ssl_context(ssl)
+        params = {}
+        [
+          :ca_file, :ca_path, :cert_store, :verify_depth,
+        ].each do |key|
+          if (value = ssl[key])
+            params[key] = value
+          end
+        end
+
+        if (client_cert = ssl_client_cert(ssl.client_cert))
+          params[:cert] = client_cert
+        end
+
+        if (client_key = ssl_client_key(ssl.client_key))
+          params[:key] = client_key
+        end
+
+        OpenSSL::SSL::SSLContext.new.tap do |ctx|
+          ctx.set_params(params)
+          if (vm = ssl.verify_mode)
+            ctx.verify_mode = vm
+          elsif ssl.disable?
+            ctx.verify_mode = OpenSSL::SSL::VERIFY_NONE
+          end
+
+          if (v = ssl.version)
+            ctx.ssl_version = v
+          end
+
+          if ctx.respond_to?(:min_version=) && (v = ssl.min_version)
+            ctx.min_version = v
+          end
+        end
+      end
+
+      def ssl_client_cert(cert)
+        case cert
+        when NilClass then return
+        when String
+          return OpenSSL::X509::Certificate.new(File.read(cert))
+        when OpenSSL::X509::Certificate
+          return cert
+        else
+          raise Faraday::Error, "invalid ssl.client_cert: #{cert.inspect}"
+        end
+      end
+
+      def ssl_client_key(cert)
+        case cert
+        when NilClass then return
+        when String
+          return OpenSSL::PKey::RSA.new(File.read(cert))
+        when OpenSSL::PKey::RSA, OpenSSL::PKey::DSA
+          return cert
+        else
+          raise Faraday::Error, "invalid ssl.client_key: #{cert.inspect}"
+        end
       end
     end
   end


### PR DESCRIPTION
SSL is cool. Followed [these instructions](https://github.com/httprb/http/wiki/HTTPS).

Also confirmed this passes faraday-live tests with:

```bash
$ FARADAY_HTTP_GEM_REF=672fb70145d468dfba2ecfd7859b92bcb33754fa docker-compose build tests
$ TEST_ADAPTER=http docker-compose run tests
```