### PR TITLE
Test error handling

### DIFF
--- a/spec/faraday/http/adapter_spec.rb
+++ b/spec/faraday/http/adapter_spec.rb
@@ -5,4 +5,68 @@ RSpec.describe Faraday::Adapter::HTTP do
            :skip_response_body_on_head, :local_socket_binding
 
   it_behaves_like 'an adapter'
+
+  # SSL options setting
+  let(:adapter) { 'HTTP' }
+
+  let(:conn_options) { { headers: { 'X-Faraday-Adapter' => adapter } } }
+
+  let(:adapter_options) do
+    []
+  end
+
+  let(:protocol) { 'https' }
+  let(:remote) { "#{protocol}://example.com" }
+
+  let(:conn) do
+    conn_options[:ssl] ||= {}
+    conn_options[:ssl][:ca_file] ||= ENV['SSL_FILE']
+
+    Faraday.new(remote, conn_options) do |conn|
+      conn.request :multipart
+      conn.request :url_encoded
+      conn.response :raise_error
+      conn.adapter described_class, *adapter_options
+    end
+  end
+
+  context 'when handling errors' do
+    it 'fails with a Faraday::SSL error for OpenSSL errors' do
+      expect_any_instance_of(described_class).to receive(:setup_connection).and_raise('foo')
+      stub_request(:get, 'https://example.com/')
+        .with(
+          headers: {
+            'Connection' => 'close',
+            'Host' => 'example.com',
+            'User-Agent' => 'Agent Faraday',
+            'X-Faraday-Adapter' => 'HTTP'
+          }
+        )
+        .to_return(status: 200, body: '', headers: {})
+
+      expect do
+        conn.get('/', nil, { user_agent: 'Agent Faraday' })
+      end.to raise_error(StandardError, 'foo')
+    end
+
+    it 'fails with a Faraday::SSL error for OpenSSL errors' do
+      expect_any_instance_of(
+        described_class
+      ).to receive(:setup_connection).and_raise(OpenSSL::SSL::SSLError, 'foo')
+      stub_request(:get, 'https://example.com/')
+        .with(
+          headers: {
+            'Connection' => 'close',
+            'Host' => 'example.com',
+            'User-Agent' => 'Agent Faraday',
+            'X-Faraday-Adapter' => 'HTTP'
+          }
+        )
+        .to_return(status: 200, body: '', headers: {})
+
+      expect do
+        conn.get('/', nil, { user_agent: 'Agent Faraday' })
+      end.to raise_error(Faraday::SSLError, 'foo')
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@
 require 'simplecov'
 SimpleCov.start do
   add_filter '/spec/'
-  minimum_coverage 94
+  minimum_coverage 95
   minimum_coverage_by_file 80
 end
 


### PR DESCRIPTION
This PR adds dumb unit tests around the behavior for "wrap errors in a Faraday::SSL error or not" for errors handled in the adapter.