### PR TITLE
gemspec: Set required_ruby_version to 2.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,11 +68,6 @@ jobs:
       - image: circleci/ruby:2.5
     <<: *shared_ruby_steps
 
-  ruby24:
-    docker:
-      - image: circleci/ruby:2.4
-    <<: *shared_ruby_steps
-
   # Currently not in use
   jruby92:
     docker:
@@ -110,12 +105,8 @@ workflows:
       - ruby25:
           requires:
             - linting
-      - ruby24:
-          requires:
-            - linting
       - deploy:
           requires:
-            - ruby24
             - ruby25
             - ruby26
           filters:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.4', '2.5', '2.6', '2.7']
+        ruby: ['2.5', '2.6', '2.7']
 
     steps:
       - uses: actions/checkout@v1

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
 
 Style/DoubleNegation:
   Enabled: false

--- a/faraday-http.gemspec
+++ b/faraday-http.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/lostisland/faraday-http'
   spec.license       = 'MIT'
 
-  spec.required_ruby_version = '>= 2.4'
+  spec.required_ruby_version = '>= 2.5'
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.


### PR DESCRIPTION
Inspired by [the Ruby maintenance schedule](https://www.ruby-lang.org/en/downloads/branches/), this PR makes this gem require a supported Ruby.


Ruby 2.5 is the oldest still-supported Ruby version, so we can, in a new gem, have another support schedule than in Faraday.

See #16

