### PR TITLE
gemspec: Drop now-unused gems

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,13 +14,11 @@ shared_ruby_steps: &shared_ruby_steps
         command: gem install bundler --no-document && bundle install --path vendor/bundle --jobs 7 --retry 15
     - run:
         name: Run tests
-        command: bundle exec rspec --require rspec_junit_formatter --format progress --format RspecJunitFormatter --out ~/test-results/rspec/results.xml
+        command: bundle exec rspec --format progress
     - save_cache:
         key: "{{ .Environment.CACHE_KEY_PREFIX }}-v1-bundler-deps-{{ .Branch }}"
         paths:
           - ./vendor/bundle
-    - store_test_results:
-        path: ~/test-results
     - persist_to_workspace:
         root: .
         paths:

--- a/faraday-http.gemspec
+++ b/faraday-http.gemspec
@@ -44,8 +44,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'rspec_junit_formatter', '~> 0.4'
-  spec.add_development_dependency 'rubocop', '~> 0.65'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'webmock', '~> 3.4'
 end


### PR DESCRIPTION
With #14, some chore gems were placed in the _Gemfile_.

This PR cleans up the gemspec: drop `rubocop`, and drop `rspec_junit_formatter`

(This is in preparation for not being on CircleCI.)