### PR TITLE
Fixes compatibility issue with ruby 2.7.0 or greater

### DIFF
--- a/faraday-http.gemspec
+++ b/faraday-http.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'http', '~> 3.0'
+  spec.add_dependency 'http', '~> 4.0'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 13.0'


### PR DESCRIPTION
`Bumps http.rb dependency to version 4`

Resolves #15 

[Related http.rb gem issue](https://github.com/httprb/http/issues/582)
