### PR TITLE
gemspec: Edit for clarity

### DIFF
--- a/faraday-http.gemspec
+++ b/faraday-http.gemspec
@@ -17,26 +17,11 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.5'
 
-  # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
-  # to allow pushing to a single host or delete this section to allow pushing to any host.
-  if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
+  spec.metadata['homepage_uri'] = spec.homepage
+  spec.metadata['source_code_uri'] = 'https://github.com/lostisland/faraday-http'
+  spec.metadata['changelog_uri'] = 'https://github.com/lostisland/faraday-http/releases'
 
-    spec.metadata['homepage_uri'] = spec.homepage
-    spec.metadata['source_code_uri'] = 'https://github.com/lostisland/faraday-http'
-    spec.metadata['changelog_uri'] = 'https://github.com/lostisland/faraday-http/releases'
-  else
-    raise 'RubyGems 2.0 or newer is required to protect against ' \
-      'public gem pushes.'
-  end
-
-  # Specify which files should be added to the gem when it is released.
-  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files = Dir.chdir(File.expand_path(__dir__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  end
-  spec.bindir        = 'exe'
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.files = Dir.glob('lib/**/*') + %w[README.md LICENSE]
   spec.require_paths = ['lib']
 
   spec.add_dependency 'http', '~> 4.0'


### PR DESCRIPTION
This PR reduces the size of the gemspec - and also the size of the distributed gem.

 - drop files not needed in the distribution, use Ruby to find these files

See #16 