### PR TITLE
Respect connection timeout options

### DIFF
--- a/lib/faraday/adapter/http.rb
+++ b/lib/faraday/adapter/http.rb
@@ -40,7 +40,7 @@ module Faraday
       def setup_connection(env)
         conn = ::HTTP
 
-        request_config(conn, env[:request]) if env[:request]
+        conn = request_config(conn, env[:request]) if env[:request]
         conn.headers(env.request_headers)
       end
 


### PR DESCRIPTION
If we don't reassign `conn` to the result of `request_config` the timeout config values are not respected.

This can be reproduced pretty easily. Create a request to something like [https://httpstat.us/200?sleep=5000](https://httpstat.us/200?sleep=5000) with a `timeout` set to 1 second using the `:net_http` adapter and it raises a `Faraday::TimeoutError`. Change the adapter to `:http` and no error is raised.

This pull request fixes that behavior.