### PR TITLE
Update RuboCop to v0.91.1 and use RuboCop::Packaging

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+require:
+  - rubocop-packaging
+
 AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,7 +22,7 @@ Layout/LineLength:
   Max: 100
 
 Metrics/AbcSize:
-  Max: 25
+  Max: 28
 
 Metrics/BlockLength:
   Exclude:
@@ -33,7 +33,7 @@ Metrics/CyclomaticComplexity:
   Max: 30
 
 Metrics/PerceivedComplexity:
-  Max: 10
+  Max: 11
 
 Layout/SpaceAroundMethodCallOperator:
   Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,6 @@ gemspec
 gem 'multipart-parser'
 
 group :lint, :development do
-  gem 'rubocop', '~> 0.82.0'
+  gem 'rubocop', '~> 0.91.1'
   gem 'rubocop-performance', '~> 1.0'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,6 @@ gem 'multipart-parser'
 
 group :lint, :development do
   gem 'rubocop', '~> 0.91.1'
+  gem 'rubocop-packaging', '~> 0.5'
   gem 'rubocop-performance', '~> 1.0'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,6 @@ SimpleCov.start do
   minimum_coverage_by_file 75
 end
 
-require 'bundler/setup'
 require 'faraday/http'
 require 'faraday_specs_setup'
 


### PR DESCRIPTION
Hi @iMacTia 👋🏻 

Interestingly, `faraday-http`  doesn't use `git`, so yay! 🎉 
So I've updated the version of RuboCop to v0.91.1 and activated its extension `rubocop-packaging` and fixed its offenses!

Hope it's all good to go! 😄 