### PR TITLE
Use better http-rb global timeout value

### DIFF
--- a/lib/faraday/adapter/http.rb
+++ b/lib/faraday/adapter/http.rb
@@ -46,7 +46,7 @@ module Faraday
 
       def request_config(conn, config)
         if (timeout = config[:timeout])
-          conn = conn.timeout(connect: timeout, read: timeout, write: timeout)
+          conn = conn.timeout(timeout)
         end
 
         if (timeout = config[:open_timeout])


### PR DESCRIPTION
Since http-rb 4.0, the http-rb gem has supported a better global timeout as `timeout(seconds)`.
https://github.com/httprb/http/pull/446

As the [http-rb wiki explains](https://github.com/httprb/http/wiki/Timeouts), using eg `timeout(3)` means that 3 seconds is an upper bound for the entire HTTP call.

The old way of doing things, before this PR, setting a faraday `timeout` value of `3` would turn into `HTTP.timeout(connect: 3, write: 3, read: 3)`, which would mean the whole HTTP call could actually take up to **9** seconds: 3 for open, 3 for write, another 3 for read.

The new way is better semantics for a single faraday `timeout` option. It's been supported since http-rb 4.0, and this Faraday adapter doesn't support any earlier http-rb.

It makes sense to change to use the new better way.

The existing functionality is not tested here; and I couldn't figure out any good way to test it. Mocking http-rb raising a timeout error would _not_ test this functionality of passing in timeout confiuration appropriately to http-rb.  I spent some time on it, but couldn't figure out any good way to test, sorry. This is not a reduction in test coverage, it already wasn't tested.