### PR TITLE
Allow http-rb gem 5.x

### DIFF
--- a/faraday-http.gemspec
+++ b/faraday-http.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'faraday', '~> 1.0'
-  spec.add_dependency 'http', '~> 4.0'
+  spec.add_dependency 'http', '>= 4.0', "< 6"
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 13.0'


### PR DESCRIPTION
the `http` gem released 5.0.0 on May 13 2021. https://rubygems.org/gems/http/versions/5.0.0

All tests in this repo pass with http 5.0.

I opted to leave both http 4.x and 5.x supported in gemfile, instead of forcing upgrade to 5.x. this seems kinder to users, with less chance of causing dependency incompatibilities in an app's entire dependency tree, and without arguably requiring a major version bump to faraday-http if it dropped support for http 4.