### PR TITLE
CI: use bundler-cache from ruby/setup-ruby

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           ruby-version: 2.7
           bundler-cache: true # 'bundle install' and cache
         env:
-          BUNDLE_WITHOUT: development,test
+          BUNDLE_WITHOUT: "development:test"
           BUNDLE_WITH: lint
 
       - name: Rubocop


### PR DESCRIPTION
This PR attempts to use `bundler-cache` also with the lint group.