### PR TITLE
Support faraday 2.0 & streaming api

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.5', '2.6', '2.7']
+        ruby: [ '2.6', '2.7', '3.0', '3.1' ]
 
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,6 @@ jobs:
           ruby-version: 2.7
           bundler-cache: true # 'bundle install' and cache
         env:
-          BUNDLE_WITHOUT: "development:test"
           BUNDLE_WITH: lint
 
       - name: Rubocop

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,9 @@ require:
 AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
+  NewCops: enable
+  SuggestExtensions: false
 
 Style/DoubleNegation:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gemspec
 # Required gems to run all Faraday tests
 
 group :lint, :development do
-  gem 'rubocop', '~> 0.91.1'
+  gem 'rubocop', '~> 1.37'
   gem 'rubocop-packaging', '~> 0.5'
   gem 'rubocop-performance', '~> 1.0'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gemspec
 
 # Required gems to run all Faraday tests
 gem 'multipart-parser'
+gem 'faraday-multipart'
 
 group :lint, :development do
   gem 'rubocop', '~> 0.91.1'

--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,6 @@ source 'https://rubygems.org'
 gemspec
 
 # Required gems to run all Faraday tests
-gem 'multipart-parser'
-gem 'faraday-multipart'
 
 group :lint, :development do
   gem 'rubocop', '~> 0.91.1'

--- a/faraday-http.gemspec
+++ b/faraday-http.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/lostisland/faraday-http'
   spec.license       = 'MIT'
 
-  spec.required_ruby_version = '>= 2.5'
+  spec.required_ruby_version = '>= 2.6'
 
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/lostisland/faraday-http'
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir.glob('lib/**/*') + %w[README.md LICENSE]
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'faraday', '~> 1.0'
+  spec.add_dependency 'faraday', '~> 2.0'
   spec.add_dependency 'http', '>= 4.0', '< 6'
 
   spec.add_development_dependency 'bundler', '~> 2.0'

--- a/faraday-http.gemspec
+++ b/faraday-http.gemspec
@@ -32,4 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'webmock', '~> 3.4'
+  spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/faraday-http.gemspec
+++ b/faraday-http.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir.glob('lib/**/*') + %w[README.md LICENSE]
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'faraday', '~> 2.0'
+  spec.add_dependency 'faraday', '~> 2.5'
   spec.add_dependency 'http', '>= 4.0', '< 6'
 
   spec.add_development_dependency 'bundler', '~> 2.0'

--- a/faraday-http.gemspec
+++ b/faraday-http.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/lostisland/faraday-http'
   spec.metadata['changelog_uri'] = 'https://github.com/lostisland/faraday-http/releases'
+  spec.metadata['rubygems_mfa_required'] = 'true'
 
   spec.files = Dir.glob('lib/**/*') + %w[README.md LICENSE]
   spec.require_paths = ['lib']
@@ -32,5 +33,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'webmock', '~> 3.4'
-  spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/lib/faraday/adapter/http.rb
+++ b/lib/faraday/adapter/http.rb
@@ -6,7 +6,6 @@ module Faraday
   class Adapter
     # HTTP.rb adapter.
     class HTTP < Faraday::Adapter
-
       # Takes the environment and performs the request.
       #
       # @param env [Faraday::Env] the request environment.
@@ -24,8 +23,8 @@ module Faraday
         connection = setup_connection(env)
 
         response = connection.request env[:method], env[:url],
-                            body: env[:body],
-                            ssl_context: ssl_context(env[:ssl])
+                                      body: env[:body],
+                                      ssl_context: ssl_context(env[:ssl])
 
         if env.stream_response?
           env.stream_response do |&on_data|
@@ -48,10 +47,10 @@ module Faraday
       end
 
       def request_with_wrapped_block(response, env)
-        if block_given?
-          while (chunk = response.body.readpartial) do
-            yield(chunk, env)
-          end
+        return unless block_given?
+
+        while (chunk = response.body.readpartial)
+          yield(chunk, env)
         end
       end
 
@@ -115,27 +114,19 @@ module Faraday
       end
 
       def ssl_client_cert(cert)
-        case cert
-        when NilClass then nil
-        when String
-          OpenSSL::X509::Certificate.new(File.read(cert))
-        when OpenSSL::X509::Certificate
-          cert
-        else
-          raise Faraday::Error, "invalid ssl.client_cert: #{cert.inspect}"
-        end
+        return nil if cert.nil?
+        return OpenSSL::X509::Certificate.new(File.read(cert)) if cert.is_a(String)
+        return cert if cert.is_a?(OpenSSL::X509::Certificate)
+
+        raise Faraday::Error, "invalid ssl.client_cert: #{cert.inspect}"
       end
 
       def ssl_client_key(cert)
-        case cert
-        when NilClass then nil
-        when String
-          OpenSSL::PKey::RSA.new(File.read(cert))
-        when OpenSSL::PKey::RSA, OpenSSL::PKey::DSA
-          cert
-        else
-          raise Faraday::Error, "invalid ssl.client_key: #{cert.inspect}"
-        end
+        return nil if cert.nil?
+        return OpenSSL::PKey::RSA.new(File.read(cert)) if cert.is_a(String)
+        return cert if cert.is_a?(OpenSSL::PKey::RSA, OpenSSL::PKey::DSA)
+
+        raise Faraday::Error, "invalid ssl.client_key: #{cert.inspect}"
       end
     end
   end

--- a/lib/faraday/http/version.rb
+++ b/lib/faraday/http/version.rb
@@ -2,6 +2,6 @@
 
 module Faraday
   module Http
-    VERSION = '1.1.0'
+    VERSION = '2.0.0'
   end
 end

--- a/spec/faraday/http/adapter_spec.rb
+++ b/spec/faraday/http/adapter_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Faraday::Adapter::HTTP do
   features :request_body_on_query_methods, :reason_phrase_parse, :trace_method, :connect_method,
-           :skip_response_body_on_head, :local_socket_binding
+           :skip_response_body_on_head, :local_socket_binding, :streaming
 
   it_behaves_like 'an adapter'
 

--- a/spec/faraday/http/adapter_spec.rb
+++ b/spec/faraday/http/adapter_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Faraday::Adapter::HTTP do
 
   let(:conn) do
     conn_options[:ssl] ||= {}
-    conn_options[:ssl][:ca_file] ||= ENV['SSL_FILE']
+    conn_options[:ssl][:ca_file] ||= ENV.fetch('SSL_FILE', nil)
 
     Faraday.new(remote, conn_options) do |conn|
       conn.request :url_encoded

--- a/spec/faraday/http/adapter_spec.rb
+++ b/spec/faraday/http/adapter_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe Faraday::Adapter::HTTP do
     conn_options[:ssl][:ca_file] ||= ENV['SSL_FILE']
 
     Faraday.new(remote, conn_options) do |conn|
-      conn.request :multipart
       conn.request :url_encoded
       conn.response :raise_error
       conn.adapter described_class, *adapter_options

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ SimpleCov.start do
 end
 
 require 'faraday/http'
+require 'faraday/multipart'
 require 'faraday_specs_setup'
 
 RSpec.configure do |config|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,7 +8,6 @@ SimpleCov.start do
 end
 
 require 'faraday/http'
-require 'faraday/multipart'
 require 'faraday_specs_setup'
 
 RSpec.configure do |config|


### PR DESCRIPTION
Hi! I tried to update the gem to make it compatible with Faraday 2 and add streaming API support.

Take a look. please @iMacTia 

<img width="926" alt="CleanShot 2022-10-21 at 11 35 54@2x" src="https://user-images.githubusercontent.com/6727425/197139793-992a226f-9714-4712-9893-36ac6fa52625.png">

Probably, I should update the CI matrix, too: remove 2.5, add 3.0+
