### PR TITLE
Fix ssl_client_cert and ssl_client_key

### DIFF
--- a/lib/faraday/adapter/http.rb
+++ b/lib/faraday/adapter/http.rb
@@ -115,7 +115,7 @@ module Faraday
 
       def ssl_client_cert(cert)
         return nil if cert.nil?
-        return OpenSSL::X509::Certificate.new(File.read(cert)) if cert.is_a(String)
+        return OpenSSL::X509::Certificate.new(File.read(cert)) if cert.is_a?(String)
         return cert if cert.is_a?(OpenSSL::X509::Certificate)
 
         raise Faraday::Error, "invalid ssl.client_cert: #{cert.inspect}"
@@ -123,8 +123,8 @@ module Faraday
 
       def ssl_client_key(cert)
         return nil if cert.nil?
-        return OpenSSL::PKey::RSA.new(File.read(cert)) if cert.is_a(String)
-        return cert if cert.is_a?(OpenSSL::PKey::RSA, OpenSSL::PKey::DSA)
+        return OpenSSL::PKey::RSA.new(File.read(cert)) if cert.is_a?(String)
+        return cert if cert.is_a?(OpenSSL::PKey::RSA) || cert.is_a?(OpenSSL::PKey::DSA)
 
         raise Faraday::Error, "invalid ssl.client_key: #{cert.inspect}"
       end

--- a/lib/faraday/http/version.rb
+++ b/lib/faraday/http/version.rb
@@ -2,6 +2,6 @@
 
 module Faraday
   module Http
-    VERSION = '2.0.0'
+    VERSION = '2.0.1'
   end
 end


### PR DESCRIPTION
## Issue
There is a bug when adding `client_cert` and `client_key` into the SSL options where an error is raised due to undefined method.

![image](https://github.com/lostisland/faraday-http/assets/45915877/08854d63-bc93-4eed-8d35-851600cbe184)

![image](https://github.com/lostisland/faraday-http/assets/45915877/fa7d191d-170a-4b52-9dca-f37fb62e0b69)

## What this PR does
- This PR uses the correct method (`is_a?`) to prevent the error from being raised. `is_a?` only accepts a single argument, this has been fixed too.
- Added specs to verify that the changes work as expected