### PR TITLE
Move dev dependencies to fix rubocop CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,12 @@ gemspec
 # Required gems to run all Faraday tests
 
 group :lint, :development do
+  gem 'bundler', '~> 2.0'
+  gem 'rake', '~> 13.0'
+  gem 'rspec', '~> 3.0'
   gem 'rubocop', '~> 1.37'
   gem 'rubocop-packaging', '~> 0.5'
   gem 'rubocop-performance', '~> 1.0'
+  gem 'simplecov'
+  gem 'webmock', '~> 3.4'
 end

--- a/faraday-http.gemspec
+++ b/faraday-http.gemspec
@@ -27,10 +27,4 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'faraday', '~> 2.5'
   spec.add_dependency 'http', '>= 4.0', '< 6'
-
-  spec.add_development_dependency 'bundler', '~> 2.0'
-  spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'simplecov'
-  spec.add_development_dependency 'webmock', '~> 3.4'
 end


### PR DESCRIPTION
## Issue
CI is failing due to rubocop.
![image](https://github.com/lostisland/faraday-http/assets/45915877/9a87ec7f-4ff0-4616-92a6-a265a8717272)

## What this change is
This PR resolves the rubocop issue by moving development dependencies declared in gemspec to Gemfile as recommended by rubocop.
